### PR TITLE
More refactors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test-2c: ARGS=2C
 
 test test-2a test-2b test-2c:
 ifdef RACE
-	go test -v -race ./test -run "$(ARGS)"
+	go test -count=1 -v -race ./test -run "$(ARGS)"
 else
-	go test -v ./test -run "$(ARGS)"
+	go test  -count=1 -v ./test -run "$(ARGS)"
 endif

--- a/leader_election.go
+++ b/leader_election.go
@@ -28,7 +28,7 @@ type RaftElectionInstance interface {
 	SetTerm(int32) int32
 	SendElectionRunningAck()
 	ReleaseElectionRunningFlag()
-	TransitionToLeader(term int)
+	TransitionToLeader(info string)
 	TransitionToFollower(info string)
 }
 
@@ -48,7 +48,7 @@ func (mgr *leaderElectionManager) RunElection(KilledChan chan struct{}, stopElec
 	mgr.raftInstance.ReleaseElectionRunningFlag()
 	switch electionResult {
 	case ELECTION_WON:
-		mgr.raftInstance.TransitionToLeader(int(mgr.raftInstance.GetCurrentTerm()))
+		mgr.raftInstance.TransitionToLeader(string(mgr.raftInstance.GetCurrentTerm()))
 		return
 	case ELECTION_EXIT:
 		// Just exit, dont tranistion to any particular state.

--- a/log_replication.go
+++ b/log_replication.go
@@ -2,11 +2,13 @@ package raft
 
 import (
 	"context"
-	"sync"
 )
 
+// ReplicationStatus represents the status of a replication operation.
+type ReplicationStatus int
+
 const (
-	REPLICATE_SUCCESS = iota
+	REPLICATE_SUCCESS ReplicationStatus = iota
 	REPLICATE_FAILURE
 	REPLICATE_EXIT
 	REPLICATE_ERR
@@ -15,7 +17,7 @@ const (
 type RaftLeader interface {
 	LastLogIndex() int
 	GetCurrentTerm() int32
-	SendAppendEntry(ctx context.Context, peer, from int, to int, currentTerm int32) (int, *AppendEntryExtras)
+	SendAppendEntry(ctx context.Context, peer, from int, to int, currentTerm int32) (ReplicationStatus, *AppendEntryExtras)
 	GetLastEntryWithTerm(term int32) *LogEntry
 	UpdateLeaderCommitIndex()
 	Log(msg string, args ...interface{})
@@ -26,69 +28,7 @@ type RaftLeader interface {
 	LogReplicationState
 }
 
-type logReplicationState struct {
-	mu         sync.RWMutex
-	peerSize   int
-	nextIndex  []int
-	matchIndex []int
-}
-
-type LogReplicationState interface {
-	NextIndex(forPeer int) int
-	MatchIndex(forPeer int) int
-	SetMatchIndex(peerIndex int, value int)
-	SetNextIndex(peerIndex int, value int)
-	MatchIndexCopy() []int
-	ResetLogReplicationState()
-}
-
-func NewLogReplicationState(peerSize int) LogReplicationState {
-	return &logReplicationState{
-		peerSize:   peerSize,
-		nextIndex:  make([]int, peerSize),
-		matchIndex: make([]int, peerSize),
-	}
-}
-
-func (rf *logReplicationState) MatchIndexCopy() []int {
-	rf.mu.RLock()
-	defer rf.mu.RUnlock()
-	res := make([]int, 0)
-	res = append(res, rf.matchIndex...)
-	return res
-}
-
-func (rf *logReplicationState) ResetLogReplicationState() {
-	rf.mu.Lock()
-	defer rf.mu.Unlock()
-	rf.nextIndex = make([]int, rf.peerSize)
-	rf.matchIndex = make([]int, rf.peerSize)
-}
-
-func (rf *logReplicationState) NextIndex(forPeer int) int {
-	rf.mu.RLock()
-	defer rf.mu.RUnlock()
-	return rf.nextIndex[forPeer]
-}
-
-func (rf *logReplicationState) MatchIndex(forPeer int) int {
-	rf.mu.RLock()
-	defer rf.mu.RUnlock()
-	return rf.matchIndex[forPeer]
-}
-
-func (rf *logReplicationState) SetMatchIndex(peerIndex int, value int) {
-	rf.mu.Lock()
-	defer rf.mu.Unlock()
-	rf.matchIndex[peerIndex] = value
-}
-
-func (rf *logReplicationState) SetNextIndex(peerIndex int, value int) {
-	rf.mu.Lock()
-	defer rf.mu.Unlock()
-	rf.nextIndex[peerIndex] = value
-}
-
+// Replicator defines methods for replicating logs to followers and stopping replication.
 type Replicator interface {
 	Replicate(tillIndex int)
 	Stop()
@@ -100,7 +40,6 @@ type replicator struct {
 	stopChan         chan struct{}
 	leader           RaftLeader
 	goRoutineManager GoRoutineManager
-	sync.Mutex
 }
 
 func NewReplicator(leader RaftLeader, forPeer int, currentTerm int32) Replicator {
@@ -120,28 +59,24 @@ func (r *replicator) Stop() {
 	close(r.stopChan)
 }
 
+// Replicate initiates replication of logs up to a specified index.
 func (r *replicator) Replicate(till int) {
 	select {
-	case r.channel <- till:
-		return
 	case <-r.stopChan:
 		return
+	default:
+		r.channel <- till
 	}
 }
 
+// Replicator main loop.
 func (r *replicator) startReplicatorLoop(currentTerm int32) {
 	defer r.leader.Log("exiting replicater loop: %d", r.peerIndex)
 	r.leader.Log("started replicator with term: %d", currentTerm)
 	for {
 		select {
 		case currentLeaderLastLogIndex := <-r.channel:
-			if currentLeaderLastLogIndex >= r.leader.NextIndex(r.peerIndex) {
-				r.replicate(r.leader.NextIndex(r.peerIndex), currentLeaderLastLogIndex, currentTerm)
-			} else if currentLeaderLastLogIndex != r.leader.MatchIndex(r.peerIndex) {
-				r.replicate(currentLeaderLastLogIndex, currentLeaderLastLogIndex, currentTerm)
-			} else {
-				go r.leader.SendHeartBeat(currentTerm, r.peerIndex)
-			}
+			r.handleReplicationRequest(currentLeaderLastLogIndex, currentTerm)
 		case <-r.stopChan:
 			r.goRoutineManager.StopAll()
 			return
@@ -149,9 +84,20 @@ func (r *replicator) startReplicatorLoop(currentTerm int32) {
 	}
 }
 
-func (r *replicator) replicate(fromIndex int, toIndex int, term int32) {
-	r.Lock()
-	defer r.Unlock()
+// handleReplicationRequest handles replication requests from the leader.
+// It sends out heartbeats to peers if the log is already uptodate.
+func (r *replicator) handleReplicationRequest(currentLeaderLastLogIndex int, currentTerm int32) {
+	switch {
+	case currentLeaderLastLogIndex >= r.leader.NextIndex(r.peerIndex):
+		r.replicateLogs(r.leader.NextIndex(r.peerIndex), currentLeaderLastLogIndex, currentTerm)
+	case currentLeaderLastLogIndex != r.leader.MatchIndex(r.peerIndex):
+		r.replicateLogs(currentLeaderLastLogIndex, currentLeaderLastLogIndex, currentTerm)
+	default:
+		go r.leader.SendHeartBeat(currentTerm, r.peerIndex)
+	}
+}
+
+func (r *replicator) replicateLogs(fromIndex int, toIndex int, term int32) {
 	currentRoutineID := createReplicatorID(fromIndex, toIndex)
 	if r.goRoutineManager.Exists(ID(currentRoutineID)) {
 		return
@@ -160,7 +106,7 @@ func (r *replicator) replicate(fromIndex int, toIndex int, term int32) {
 	go func() {
 		defer close(exitChan)
 		for {
-			res := r.replicateF(ctxWithCancel, fromIndex, toIndex, term)
+			res := r.replicateLogsHelper(ctxWithCancel, fromIndex, toIndex, term)
 			switch res {
 			case REPLICATE_EXIT:
 				return
@@ -170,12 +116,10 @@ func (r *replicator) replicate(fromIndex int, toIndex int, term int32) {
 		}
 	}()
 	// Stop all other in flight replicate routines with ID less than the current ID.
-	r.goRoutineManager.Stop(func(id ID) bool {
-		return id < ID(currentRoutineID)
-	})
+	r.stopPreviousReplicationRoutines(ID(currentRoutineID))
 }
 
-func (r *replicator) replicateF(ctx context.Context, fromIndex int, toIndex int, currentTerm int32) int {
+func (r *replicator) replicateLogsHelper(ctx context.Context, fromIndex int, toIndex int, currentTerm int32) ReplicationStatus {
 	defer r.leader.Log("exiting replicate func. peer: %d", r.peerIndex)
 	if !r.leader.IsLeader() || fromIndex == 0 {
 		return REPLICATE_EXIT
@@ -183,30 +127,43 @@ func (r *replicator) replicateF(ctx context.Context, fromIndex int, toIndex int,
 	r.leader.Log("replicating from %d to %d for peer: %d", fromIndex, toIndex, r.peerIndex)
 	res, extraInfo := r.leader.SendAppendEntry(ctx, r.peerIndex, fromIndex, toIndex, currentTerm)
 	switch {
-	case res == REPLICATE_ERR:
-		return REPLICATE_ERR
 	case !r.leader.IsLeader():
 		return REPLICATE_EXIT
 	case res == REPLICATE_FAILURE:
-		r.leader.Log("failed to replicate. Info from follower[%d]: %#v", r.peerIndex, extraInfo)
-		if extraInfo.Xterm == -1 {
-			if extraInfo.XLen == 0 {
-				return r.replicateF(ctx, 1, toIndex, currentTerm)
-			}
-			return r.replicateF(ctx, extraInfo.XLen, toIndex, currentTerm)
-		}
-		lastLeaderEntryWithConflictingTerm := r.leader.GetLastEntryWithTerm(extraInfo.Xterm)
-		if lastLeaderEntryWithConflictingTerm == nil {
-			return r.replicateF(ctx, extraInfo.XIndex, toIndex, currentTerm)
-		} else {
-			return r.replicateF(ctx, lastLeaderEntryWithConflictingTerm.LogIndex, toIndex, currentTerm)
-		}
+		return r.handleReplicationFailure(ctx, extraInfo, toIndex, currentTerm)
 	case res == REPLICATE_SUCCESS:
-		r.leader.SetMatchIndex(r.peerIndex, toIndex)
-		r.leader.SetNextIndex(r.peerIndex, toIndex+1)
-		r.leader.UpdateLeaderCommitIndex()
-	case res == REPLICATE_EXIT:
-		return REPLICATE_EXIT
+		r.updateLeaderReplicationIndexes(toIndex)
+		return REPLICATE_SUCCESS
 	}
-	return REPLICATE_SUCCESS
+	return res
+}
+
+// handleReplicationFailure handles replication failures.
+func (r *replicator) handleReplicationFailure(ctx context.Context, extraInfo *AppendEntryExtras, toIndex int, currentTerm int32) ReplicationStatus {
+	r.leader.Log("failed to replicate. Info from follower[%d]: %#v", r.peerIndex, extraInfo)
+	if extraInfo.Xterm == -1 {
+		if extraInfo.XLen == 0 {
+			return r.replicateLogsHelper(ctx, 1, toIndex, currentTerm)
+		}
+		return r.replicateLogsHelper(ctx, extraInfo.XLen, toIndex, currentTerm)
+	}
+	lastLeaderEntryWithConflictingTerm := r.leader.GetLastEntryWithTerm(extraInfo.Xterm)
+	if lastLeaderEntryWithConflictingTerm == nil {
+		return r.replicateLogsHelper(ctx, extraInfo.XIndex, toIndex, currentTerm)
+	}
+	return r.replicateLogsHelper(ctx, lastLeaderEntryWithConflictingTerm.LogIndex, toIndex, currentTerm)
+}
+
+// stopPreviousReplicationRoutines stops all previous replication routines.
+func (r *replicator) stopPreviousReplicationRoutines(currentRoutineID ID) {
+	r.goRoutineManager.Stop(func(id ID) bool {
+		return id < currentRoutineID
+	})
+}
+
+// updateReplicationIndexes updates the match and next indexes.
+func (r *replicator) updateLeaderReplicationIndexes(matchIndex int) {
+	r.leader.SetMatchIndex(r.peerIndex, matchIndex)
+	r.leader.SetNextIndex(r.peerIndex, matchIndex+1)
+	r.leader.UpdateLeaderCommitIndex()
 }

--- a/raft.go
+++ b/raft.go
@@ -30,7 +30,10 @@ import (
 	"github.com/google/uuid"
 )
 
-var leaderTickerDuration = time.Duration(250 * time.Millisecond)
+const (
+	DEBUG                = false
+	leaderTickerDuration = time.Duration(250 * time.Millisecond)
+)
 
 type ApplyMsg struct {
 	CommandValid bool
@@ -358,7 +361,7 @@ func Make(peers []RaftPeer, me int,
 		stopElectionChan: make(chan struct{}),
 		killedChan:       make(chan struct{}),
 		applyCh:          applyCh,
-		debug:            false,
+		debug:            DEBUG,
 	}
 
 	stopLeaderChan := make(chan struct{})

--- a/raft_common.go
+++ b/raft_common.go
@@ -1,0 +1,198 @@
+package raft
+
+func (rf *Raft) LastLogIndex() int {
+	rf.mu.RLock()
+	defer rf.mu.RUnlock()
+	return len(rf.logContents)
+}
+
+func (rf *Raft) GetCommitIndex() int {
+	rf.mu.RLock()
+	defer rf.mu.RUnlock()
+	return rf.commitIndex
+}
+
+func (rf *Raft) GetLogEntryAt(at int) LogEntry {
+	rf.mu.RLock()
+	defer rf.mu.RUnlock()
+	return rf.logContents[at]
+}
+
+func (rf *Raft) LastLogTerm() int32 {
+	rf.mu.RLock()
+	defer rf.mu.RUnlock()
+	if len(rf.logContents) == 0 {
+		return 0
+	}
+	return rf.logContents[len(rf.logContents)-1].Term
+}
+
+func (rf *Raft) lastLogTerm() int32 {
+	if len(rf.logContents) == 0 {
+		return 0
+	}
+	return rf.logContents[len(rf.logContents)-1].Term
+}
+
+func (rf *Raft) LogLength() int {
+	rf.mu.RLock()
+	defer rf.mu.RUnlock()
+	return len(rf.logContents)
+}
+
+func (rf *Raft) logLength() int {
+	return len(rf.logContents)
+}
+
+func (rf *Raft) GetCurrentTerm() int32 {
+	rf.mu.RLock()
+	defer rf.mu.RUnlock()
+	return rf.currentTerm
+}
+
+func (rf *Raft) getCurrentTerm() int32 {
+	return rf.currentTerm
+}
+
+func (rf *Raft) Peers() []RaftPeer {
+	return rf.peers
+}
+
+func (rf *Raft) Me() int {
+	return rf.me
+}
+
+func (rf *Raft) GetCandidateID() string {
+	return rf.candidateID
+}
+
+func (rf *Raft) VoteForSelf() {
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+	rf.votedFor = &VotedFor{
+		Candidate: rf.candidateID,
+		Term:      rf.currentTerm,
+	}
+	rf.persist()
+}
+
+func (rf *Raft) voteForSelf() {
+	rf.votedFor = &VotedFor{
+		Candidate: rf.candidateID,
+		Term:      rf.currentTerm,
+	}
+	rf.persist()
+}
+
+func (rf *Raft) SetTerm(to int32) int32 {
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+	if to > rf.currentTerm {
+		rf.currentTerm = to
+		rf.votedFor = nil
+		rf.persist()
+	}
+	return rf.currentTerm
+}
+
+func (rf *Raft) setTerm(to int32) int32 {
+	if to > rf.currentTerm {
+		rf.currentTerm = to
+		rf.votedFor = nil
+		rf.persist()
+	}
+	return rf.currentTerm
+}
+
+func (rf *Raft) IncrementTerm() {
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+	rf.currentTerm += 1
+	rf.votedFor = nil
+	rf.persist()
+}
+
+func (rf *Raft) incrementTerm() {
+	rf.currentTerm += 1
+	rf.votedFor = nil
+	rf.persist()
+}
+
+func (rf *Raft) GetCurrentLeader() RaftPeer {
+	rf.mu.RLock()
+	defer rf.mu.RUnlock()
+	return rf.currentLeader
+}
+
+func (rf *Raft) getCurrentLeader() RaftPeer {
+	return rf.currentLeader
+}
+
+func (rf *Raft) SetCurrentLeader(leader RaftPeer) {
+	rf.mu.Lock()
+	defer rf.mu.Unlock()
+	rf.currentLeader = leader
+}
+
+func (rf *Raft) setCurrentLeader(leader RaftPeer) {
+	rf.currentLeader = leader
+}
+
+func (rf *Raft) GetFirstEntryWithTerm(term int32) LogEntry {
+	rf.mu.RLock()
+	defer rf.mu.RUnlock()
+	return rf.getFirstEntryWithTerm(term)
+}
+
+func (rf *Raft) getFirstEntryWithTerm(term int32) LogEntry {
+	for _, entry := range rf.logContents {
+		if entry.Term == term {
+			return entry
+		}
+	}
+	return LogEntry{
+		LogIndex: -1,
+	}
+}
+
+func (rf *Raft) GetLastEntryWithTerm(term int32) *LogEntry {
+	rf.mu.RLock()
+	defer rf.mu.RUnlock()
+	return rf.getLastEntryWithTerm(term)
+}
+
+func (rf *Raft) getLastEntryWithTerm(term int32) *LogEntry {
+	currLen := len(rf.logContents)
+	for i := currLen - 1; i >= 0; i-- {
+		curr := rf.logContents[i]
+		if curr.Term == term {
+			return &curr
+		}
+	}
+	return nil
+}
+
+func (rf *Raft) getLogLen() int {
+	return len(rf.logContents)
+}
+
+func (rf *Raft) GetLogLen() int {
+	rf.mu.RLock()
+	defer rf.mu.RUnlock()
+	return len(rf.logContents)
+}
+
+func (rf *Raft) Lock() {
+	rf.mu.Lock()
+}
+
+func (rf *Raft) Unlock() {
+	rf.mu.Unlock()
+}
+
+// The caller needs to hold the mutex when calling this method.
+func (rf *Raft) SafeTransitionWithMutex(fn StateTransitionFn, info string) {
+	rf.mu.Unlock()
+	fn(info)
+	rf.mu.Lock()
+}

--- a/raft_node_state_manager.go
+++ b/raft_node_state_manager.go
@@ -10,12 +10,14 @@ import (
 
 const timeoutDuration = time.Millisecond * 100
 
+type StateTransitionFn func(info string)
+
 type StateManager interface {
 	IsFollower() bool
 	IsLeader() bool
 	IsElectionRunning() bool
-	TransitionToCandidate()
-	TransitionToLeader(term int)
+	TransitionToCandidate(info string)
+	TransitionToLeader(info string)
 	TransitionToFollower(info string)
 	LeaderChan() chan struct{}
 	CandidateChan() chan struct{}
@@ -116,7 +118,7 @@ func (s *stateManager) ReleaseFollowerFlag() {
 	s.followerRoutineRunning.Store(false)
 }
 
-func (s *stateManager) TransitionToCandidate() {
+func (s *stateManager) TransitionToCandidate(info string) {
 	s.Lock()
 	defer s.Unlock()
 	if s.isElectionRunning() {
@@ -151,7 +153,7 @@ func (s *stateManager) TransitionToCandidate() {
 	}
 }
 
-func (s *stateManager) TransitionToLeader(term int) {
+func (s *stateManager) TransitionToLeader(info string) {
 	s.Lock()
 	defer s.Unlock()
 	if s.isLeader() {
@@ -159,10 +161,10 @@ func (s *stateManager) TransitionToLeader(term int) {
 	}
 
 	if s.isFollower() {
-		s.blockingNotifyWithAckWhile(s.stopFollowerChan, fmt.Sprintf("[term: %d]stop follower, becoming leader", term), s.isFollower)
+		s.blockingNotifyWithAckWhile(s.stopFollowerChan, fmt.Sprintf("[term: %d]stop follower, becoming leader", info), s.isFollower)
 	}
 	if s.isElectionRunning() {
-		s.blockingNotifyWhile(s.stopElectionChan, fmt.Sprintf("[term: %d]stop election, becoming leader", term), s.isElectionRunning)
+		s.blockingNotifyWhile(s.stopElectionChan, fmt.Sprintf("[term: %d]stop election, becoming leader", info), s.isElectionRunning)
 	}
 	ctx1, cancelFn1 := context.WithTimeout(context.Background(), timeoutDuration)
 	defer cancelFn1()
@@ -183,7 +185,7 @@ func (s *stateManager) TransitionToLeader(term int) {
 	case <-s.leaderAckChannel:
 		break
 	case <-ctx2.Done():
-		panic(fmt.Sprintf("[term: %d]failed to receive ack from leader", term))
+		panic(fmt.Sprintf("[term: %d]failed to receive ack from leader", info))
 	}
 }
 
@@ -262,7 +264,7 @@ func (s *stateManager) SendTransitionedToLeaderAck() {
 }
 
 func (s *stateManager) blockingNotifyWithAckWhile(channel chan struct{}, action string, condFn func() bool) {
-	ctx, cancelFn := context.WithTimeout(context.Background(), time.Millisecond*50)
+	ctx, cancelFn := context.WithTimeout(context.Background(), time.Millisecond*100)
 	defer cancelFn()
 	for condFn() {
 		select {
@@ -288,7 +290,7 @@ func (s *stateManager) blockingNotifyWithAckWhile(channel chan struct{}, action 
 }
 
 func (s *stateManager) blockingNotifyWhile(channel chan struct{}, action string, condFn func() bool) {
-	ctx, cancelFn := context.WithTimeout(context.Background(), time.Millisecond*50)
+	ctx, cancelFn := context.WithTimeout(context.Background(), time.Millisecond*100)
 	defer cancelFn()
 	for condFn() {
 		select {

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Define the test command
-TEST_COMMAND="go test -run ^TestBackup2B"
+TEST_COMMAND="go test -run 2C"
 # Initialize iteration counter
 iterations=0 
 


### PR DESCRIPTION
- Move common raft attribute reader and writer methods to a common file
- Rafactor appendentries rpc to acquire lock at the start of the request
  processing
- Dont update follower commit index to leaders commit index, instead use
  min(leader_commit_index, leaderPrevLogIndex + len(incoming log entries))
- While transitioning a raft server from within an RPC, release and
  reacquire the lock so that background go-routines are not blocked.
